### PR TITLE
feat(core): add UI channel functionality to createNeuroUX

### DIFF
--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -6,3 +6,4 @@ export * from './lib/state';
 export * from './lib/rule-processor';
 export * from './lib/event-bus';
 export * from './lib/signals';
+export * from './lib/ui-channel';

--- a/libs/core/src/lib/ui-channel.test.ts
+++ b/libs/core/src/lib/ui-channel.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createUiChannel, UiChannel } from './ui-channel';
+
+describe('createUiChannel', () => {
+  describe('initialization', () => {
+    it('should create a UI channel', () => {
+      const channel = createUiChannel();
+
+      expect(channel).toBeDefined();
+      expect(channel).toHaveProperty('set');
+      expect(channel).toHaveProperty('get');
+      expect(channel).toHaveProperty('getAll');
+      expect(channel).toHaveProperty('onUpdate');
+    });
+
+    it('should implement the UiChannel interface', () => {
+      const channel = createUiChannel();
+
+      const channelTyped: UiChannel = channel;
+      expect(channelTyped.set).toBeDefined();
+      expect(channelTyped.get).toBeDefined();
+      expect(channelTyped.getAll).toBeDefined();
+      expect(channelTyped.onUpdate).toBeDefined();
+    });
+  });
+
+  describe('set and get', () => {
+    it('should set and get a value', () => {
+      const channel = createUiChannel();
+
+      channel.set('key1', 'value1');
+      expect(channel.get('key1')).toBe('value1');
+    });
+
+    it('should overwrite existing values', () => {
+      const channel = createUiChannel();
+
+      channel.set('key1', 'value1');
+      channel.set('key1', 'value2');
+      expect(channel.get('key1')).toBe('value2');
+    });
+
+    it('should handle different value types', () => {
+      const channel = createUiChannel();
+
+      channel.set('string', 'text');
+      channel.set('number', 42);
+      channel.set('boolean', true);
+      channel.set('object', { nested: 'value' });
+      channel.set('array', [1, 2, 3]);
+      channel.set('null', null);
+      channel.set('undefined', undefined);
+
+      expect(channel.get('string')).toBe('text');
+      expect(channel.get('number')).toBe(42);
+      expect(channel.get('boolean')).toBe(true);
+      expect(channel.get('object')).toEqual({ nested: 'value' });
+      expect(channel.get('array')).toEqual([1, 2, 3]);
+      expect(channel.get('null')).toBeNull();
+      expect(channel.get('undefined')).toBeUndefined();
+    });
+
+    it('should return undefined for non-existent keys', () => {
+      const channel = createUiChannel();
+
+      expect(channel.get('non-existent')).toBeUndefined();
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return an empty object initially', () => {
+      const channel = createUiChannel();
+
+      expect(channel.getAll()).toEqual({});
+    });
+
+    it('should return all stored values', () => {
+      const channel = createUiChannel();
+
+      channel.set('key1', 'value1');
+      channel.set('key2', 'value2');
+      channel.set('key3', 'value3');
+
+      const all = channel.getAll();
+      expect(all).toEqual({
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+      });
+    });
+
+    it('should return a copy of the state', () => {
+      const channel = createUiChannel();
+
+      channel.set('key1', 'value1');
+      const all1 = channel.getAll();
+      const all2 = channel.getAll();
+
+      expect(all1).not.toBe(all2);
+      expect(all1).toEqual(all2);
+    });
+  });
+
+  describe('onUpdate', () => {
+    it('should call handler when set is called', () => {
+      const channel = createUiChannel();
+      const handler = vi.fn();
+
+      channel.onUpdate(handler);
+      channel.set('key1', 'value1');
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith({ key1: 'value1' });
+    });
+
+    it('should call handler with correct updates', () => {
+      const channel = createUiChannel();
+      const handler = vi.fn();
+
+      channel.onUpdate(handler);
+      channel.set('key1', 'value1');
+      channel.set('key2', 'value2');
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(handler).toHaveBeenNthCalledWith(1, { key1: 'value1' });
+      expect(handler).toHaveBeenNthCalledWith(2, { key2: 'value2' });
+    });
+
+    it('should support multiple handlers', () => {
+      const channel = createUiChannel();
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+
+      channel.onUpdate(handler1);
+      channel.onUpdate(handler2);
+      channel.set('key1', 'value1');
+
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow unsubscribing handlers', () => {
+      const channel = createUiChannel();
+      const handler = vi.fn();
+
+      const unsubscribe = channel.onUpdate(handler);
+      channel.set('key1', 'value1');
+
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      channel.set('key2', 'value2');
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call handler when value is the same', () => {
+      const channel = createUiChannel();
+      const handler = vi.fn();
+
+      channel.onUpdate(handler);
+      channel.set('key1', 'value1');
+      channel.set('key1', 'value1');
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('event emission', () => {
+    it('should emit ui:update event when onEmit is provided', () => {
+      const emit = vi.fn();
+      const channel = createUiChannel(emit);
+
+      channel.set('key1', 'value1');
+
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit).toHaveBeenCalledWith('ui:update', { key1: 'value1' });
+    });
+
+    it('should not emit event when onEmit is not provided', () => {
+      const channel = createUiChannel();
+
+      expect(() => {
+        channel.set('key1', 'value1');
+      }).not.toThrow();
+    });
+
+    it('should emit event for each set operation', () => {
+      const emit = vi.fn();
+      const channel = createUiChannel(emit);
+
+      channel.set('key1', 'value1');
+      channel.set('key2', 'value2');
+      channel.set('key3', 'value3');
+
+      expect(emit).toHaveBeenCalledTimes(3);
+      expect(emit).toHaveBeenNthCalledWith(1, 'ui:update', { key1: 'value1' });
+      expect(emit).toHaveBeenNthCalledWith(2, 'ui:update', { key2: 'value2' });
+      expect(emit).toHaveBeenNthCalledWith(3, 'ui:update', { key3: 'value3' });
+    });
+  });
+
+  describe('integration', () => {
+    it('should work correctly with multiple operations', () => {
+      const channel = createUiChannel();
+      const handler = vi.fn();
+
+      channel.onUpdate(handler);
+
+      channel.set('key1', 'value1');
+      channel.set('key2', 'value2');
+      const value1 = channel.get('key1');
+      const value2 = channel.get('key2');
+      const all = channel.getAll();
+
+      expect(value1).toBe('value1');
+      expect(value2).toBe('value2');
+      expect(all).toEqual({ key1: 'value1', key2: 'value2' });
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle complex nested objects', () => {
+      const channel = createUiChannel();
+      const complexObject = {
+        nested: {
+          deep: {
+            value: 'test',
+          },
+        },
+        array: [1, 2, { item: 'value' }],
+      };
+
+      channel.set('complex', complexObject);
+      const retrieved = channel.get('complex');
+
+      expect(retrieved).toEqual(complexObject);
+    });
+  });
+});

--- a/libs/core/src/lib/ui-channel.ts
+++ b/libs/core/src/lib/ui-channel.ts
@@ -1,0 +1,57 @@
+export type UiUpdateHandler = (updates: Record<string, any>) => void;
+
+export interface UiChannel {
+  set(key: string, value: any): void;
+  get(key: string): any;
+  getAll(): Record<string, any>;
+  onUpdate(handler: UiUpdateHandler): () => void;
+}
+
+/**
+ * Creates a UI channel for managing UI adaptation outputs.
+ * The channel maintains internal state and emits events when updates occur.
+ */
+export function createUiChannel(
+  onEmit?: (event: string, payload: any) => void
+): UiChannel {
+  const state: Record<string, any> = {};
+  const updateHandlers = new Set<UiUpdateHandler>();
+
+  function set(key: string, value: any) {
+    // Only update if value actually changed
+    if (state[key] === value) {
+      return;
+    }
+    
+    state[key] = value;
+    const updates = { [key]: value };
+    
+    // Notify all handlers
+    updateHandlers.forEach((handler) => handler(updates));
+    
+    // Emit event if event bus is provided
+    if (onEmit) {
+      onEmit('ui:update', updates);
+    }
+  }
+
+  function get(key: string): any {
+    return state[key];
+  }
+
+  function getAll(): Record<string, any> {
+    return { ...state };
+  }
+
+  function onUpdate(handler: UiUpdateHandler): () => void {
+    updateHandlers.add(handler);
+    return () => updateHandlers.delete(handler);
+  }
+
+  return {
+    set,
+    get,
+    getAll,
+    onUpdate,
+  };
+}


### PR DESCRIPTION
## 📌 Summary

This PR implements the **UI Output Channel (v0.1)** for the NeuroUX Core, providing a dedicated subsystem responsible for broadcasting UI adaptation results. The UI Channel serves as the bridge between the Rule Processor and UI frameworks, enabling the Core to expose adaptation updates to React, Vue, Angular, and other framework wrappers.

**Key Changes:**
- Created `createUiChannel()` factory function with `set()`, `get()`, `getAll()`, and `onUpdate()` methods
- Integrated UI Channel into `createNeuroUX()` engine
- Connected Rule Processor to automatically write updates to the UI Channel
- UI Channel updates now propagate to Core's internal `state.ui`
- Added `"ui:update"` event emission through the event bus
- Comprehensive test coverage (19 unit tests + 10 integration tests)

---

## 🧠 Motivation

This change is needed because:

- The **Rule Processor** exists but had no way to deliver adaptation results to the UI layer
- **Signals** can update state, but there was no unified channel for UI adaptation outputs
- Framework wrappers (React, Vue, Angular, etc.) need a consistent way to listen for UI changes
- Without this module, the Core cannot deliver any adaptive behavior to the UI

This implementation is the foundation for connecting NeuroUX to UI frameworks and is required before building framework-specific wrappers.

**Related Issue:** Implements the "Create UI Output Channel (v0.1)" feature

---

## 🛠️ Type of Change

Select one:

- [x] 🚀 Feature  
- [ ] 🐞 Bug fix  
- [ ] 📚 Documentation  
- [ ] 🧹 Refactor  
- [ ] 🧪 Tests  
- [ ] 🔧 Build / CI  
- [ ] Other (specify):

---

## 🧪 How to Test

### Running Tests

1. Navigate to the core package:
   ```bash
   cd libs/core
   ```

2. Run the test suite:
   ```bash
   npm test
   ```

3. Verify all tests pass (129 tests total):
   - 19 tests for `ui-channel.test.ts`
   - 32 tests for `createNeuroUX.test.ts` (including 10 new UI channel integration tests)
   - All existing tests continue to pass

### Manual Testing

1. Create a NeuroUX instance:
   ```typescript
   import { createNeuroUX } from '@adapt-ux/neuro-core';
   
   const neuro = createNeuroUX();
   ```

2. Test UI Channel methods:
   ```typescript
   // Set UI values
   neuro.ui.set('theme', 'dark');
   neuro.ui.set('fontSize', 'large');
   
   // Read UI values
   const theme = neuro.ui.get('theme'); // 'dark'
   const all = neuro.ui.getAll(); // { theme: 'dark', fontSize: 'large' }
   
   // Subscribe to updates
   neuro.ui.onUpdate((updates) => {
     console.log('UI updated:', updates);
   });
   ```

3. Test event emission:
   ```typescript
   neuro.on('ui:update', (updates) => {
     console.log('UI update event:', updates);
   });
   
   neuro.ui.set('key', 'value'); // Triggers 'ui:update' event
   ```

4. Verify state synchronization:
   ```typescript
   neuro.ui.set('key', 'value');
   const state = neuro.getState();
   console.log(state.ui); // { key: 'value' }
   ```

5. Verify Rule Processor integration:
   ```typescript
   // Rule processor automatically evaluates on state changes
   neuro.setState({ profile: 'new-profile' });
   // Rule processor evaluates and writes to UI channel (currently returns {})
   ```

---

## 📦 Affected Packages

Mark all that apply:

- [x] `core`
- [ ] `assist`
- [ ] `styles`
- [ ] `signals`
- [ ] `utils`
- [ ] `neuro-react`
- [ ] `neuro-vue`
- [ ] `neuro-angular`
- [ ] `neuro-svelte`
- [ ] `neuro-js`
- [ ] `neuro-next`
- [ ] `demo`

---

## ✔ Checklist

Before submitting:

- [x] Code builds with no errors (`nx run-many --target=build --all`)
- [x] Tests pass (`nx run-many --target=test --all`)
- [x] I added or updated tests when needed
- [ ] I updated documentation where appropriate
- [x] I followed the project's coding conventions
- [x] I used Conventional Commits
- [x] I have reviewed the **Code of Conduct**

---

## 📸 Screenshots / Demos (if applicable)

N/A - This is a core infrastructure change with no visual UI components.

---

## 🔒 Security Considerations

Does this PR introduce potential security concerns?

- [x] No
- [ ] Yes (explain below)

---

## 🗒 Additional Notes

### Implementation Details

**New Files:**
- `libs/core/src/lib/ui-channel.ts` - UI Channel factory implementation
- `libs/core/src/lib/ui-channel.test.ts` - Comprehensive test suite

**Modified Files:**
- `libs/core/src/lib/createNeuroUX.ts` - Integrated UI Channel and Rule Processor
- `libs/core/src/lib/createNeuroUX.test.ts` - Added 10 integration tests
- `libs/core/src/index.ts` - Exported UI Channel types and factory

### Key Features

1. **UI Channel Factory** (`createUiChannel`)
   - Maintains internal state of UI outputs
   - Prevents unnecessary updates when values don't change
   - Supports event emission through optional callback

2. **Integration with Core**
   - UI Channel automatically updates `state.ui` when values change
   - Rule Processor evaluates on state changes and writes to UI Channel
   - Events are emitted through the main event bus

3. **Event System**
   - `"ui:update"` events are emitted for each UI change
   - Compatible with existing `"signal:update"` events
   - Framework wrappers can subscribe to UI changes

### Acceptance Criteria Met

✅ When the Rule Processor emits UI output (even empty `{}`), the UI Channel receives it  
✅ UI changes propagate to internal Core state (`state.ui`)  
✅ UI changes emit `"ui:update"` events  
✅ Framework wrappers can listen for UI changes in a unified way  
✅ No UI implementation exists (DOM, browser APIs, CSS, etc.) — only the channel

### Out of Scope (v0.1)

As specified in the issue, the following are intentionally not included:
- Styling or CSS generation
- Animations
- Concrete UI bindings
- View Layer API
- Adaptive CSS
- Decorators
- DOM utilities

These will be implemented in future modules (`@adapt-ux/neuro-styles`, `@adapt-ux/neuro-assist`, `@adapt-ux/neuro-react`, etc.).

### Next Steps

After this PR is merged, the next logical step is implementing **"Rule Processor v1 — Declarative Adaptive Rules"** to make the Rule Processor actually produce meaningful UI adaptation outputs.
