### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+NeuroUX SDK is an Nx monorepo of framework-agnostic adaptive-UX packages under `libs/*`
+(core, signals, styles, assist, utils, and framework wrappers `neuro-react/vue/angular/svelte/js/next`),
+plus a browser demo app in `apps/demo`.
+
+### Package manager
+- Despite `CONTRIBUTING.md`/`README.md` mentioning pnpm, this repo is driven by **npm**: the committed
+  lockfile is `package-lock.json` and CI (`.github/workflows/ci.yml`) uses `npm ci --legacy-peer-deps`.
+  Always use npm. `--legacy-peer-deps` is required (Angular 18 / React 19 peer-dependency conflicts).
+
+### Standard commands (see `README.md` and `.github/workflows/ci.yml`)
+- Lint all: `npx nx run-many --target=lint --all`
+- Test all: `npx nx run-many --target=test --all` (Vitest; jsdom)
+- Build: libs intentionally have **no `build` target** (they publish source directly to avoid nx
+  recursion), so `npx nx run-many --target=build --all --exclude=demo` runs no tasks — this is expected,
+  not an error.
+- Run the demo (dev): `npx nx serve demo` → serves on http://localhost:4200 (webpack dev server).
+
+### Non-obvious gotchas
+- The `demo` app is **excluded from the CI build** because `apps/demo/src/main.ts` and
+  `libs/styles/src/index.ts` currently emit TypeScript **type** errors. These are type-only errors:
+  `npx nx serve demo` still emits a working bundle and the app runs correctly in the browser (webpack
+  briefly shows an error overlay on first compile, then the app renders). Do not treat the demo's
+  type errors as a broken dev environment.
+- Lint currently passes with warnings only (unused vars / `no-explicit-any`); warnings do not fail lint.
+- `.husky/pre-commit` runs `nx affected:test` but is intentionally non-blocking (always exits 0).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the NeuroUX SDK Nx monorepo, and adds `AGENTS.md` capturing durable, non-obvious setup guidance for future cloud agents.

No application code was modified.

## Environment verification

- Dependencies installed via `npm ci --legacy-peer-deps` (repo is npm-driven despite pnpm mentions in docs).
- Lint, tests, and the demo dev server all run successfully.
- Demo app hello-world flow verified in the browser: clicking the "Vibrant Mode" and "Toggle Highlight" buttons updates the UI Channel, CSS Variables, and Recent Events in the Debug Panel, with Engine Status "Running".

### Walkthrough

[neuroux_demo_hello_world.mp4](https://cursor.com/agents/bc-bbf0806d-2d58-4fb7-aa93-88e51a966ed9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fneuroux_demo_hello_world.mp4)

Demo app updating state in response to toggle interactions.

[Demo after Vibrant Mode toggle](https://cursor.com/agents/bc-bbf0806d-2d58-4fb7-aa93-88e51a966ed9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_vibrant_mode.webp)

## Notes

- The `demo` app has pre-existing TypeScript **type** errors (already excluded from the CI build); the webpack dev server still emits a working bundle and the app runs. Documented in `AGENTS.md`.
- Libs intentionally have no `build` target, so `nx run-many --target=build` runs no tasks — expected.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbf0806d-2d58-4fb7-aa93-88e51a966ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbf0806d-2d58-4fb7-aa93-88e51a966ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

